### PR TITLE
Fix GenericDisposable should be able to be disposed more than once

### DIFF
--- a/CoreTechs.Common/GenericDisposable.cs
+++ b/CoreTechs.Common/GenericDisposable.cs
@@ -17,10 +17,12 @@ namespace CoreTechs.Common
 
         public void Dispose()
         {
+            if (Disposed)
+                return;
             lock (_mutex)
             {
                 if (Disposed)
-                    throw new ObjectDisposedException("Already disposed");
+                    return;
 
                 try
                 {

--- a/Tests/DisposableTests.cs
+++ b/Tests/DisposableTests.cs
@@ -26,13 +26,16 @@ namespace Tests
         }
 
         [Test]
-        public void CantDisposeGenericDisposableMoreThanOnce()
+        public void CanDisposeGenericDisposableMoreThanOnceWithNoEffect()
         {
-            var d = this.AsDisposable(_ => { });
+            var num = 0;
+            var d = this.AsDisposable(_ => { ++num; });
             Assert.False(d.Disposed);
             d.Dispose();
+            Assert.AreEqual(num, 1);
             Assert.True(d.Disposed);
-            Assert.Throws<ObjectDisposedException>(() => d.Dispose());
+            d.Dispose();
+            Assert.AreEqual(num, 1);
         }
     }
 }


### PR DESCRIPTION
According to the [IDisposable documentation](https://msdn.microsoft.com/en-us/library/system.idisposable.dispose.aspx), IDisposables should be capable of being disposed more than once without error.