### PR TITLE
Improve delegate comparer

### DIFF
--- a/CoreTechs.Common/DelegateEqualityComparer.cs
+++ b/CoreTechs.Common/DelegateEqualityComparer.cs
@@ -17,11 +17,17 @@ namespace CoreTechs.Common
 
         public bool Equals(T x, T y)
         {
+            if (ReferenceEquals(x, y))
+                return true;
+            if (x == null || y == null)
+                return false;
             return _equals(x, y);
         }
 
         public int GetHashCode(T obj)
         {
+            if (obj == null)
+                return 0;
             return _hash(obj);
         }
     }

--- a/CoreTechs.Common/EnumerableExtensions.cs
+++ b/CoreTechs.Common/EnumerableExtensions.cs
@@ -349,5 +349,32 @@ namespace CoreTechs.Common
             foreach (var item in list)
                 yield return item;
         }
+
+        /// <summary>
+        /// Gets the distinct elements of sequence based on what equalsImpl decides are equal elements.
+        /// </summary>
+        /// <remarks>Provide a hashImpl for more speed.</remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="seq">The sequence that is being enumerated</param>
+        /// <param name="equalsImpl">
+        ///     An implementation of function that tests equality of the type emitted by the enumerable
+        /// </param>
+        /// <param name="hashImpl">
+        ///     Optional. An implementation that returns a hash that can be used to improve performance
+        /// </param>
+        /// <exception cref="System.ArgumentNullException">When either seq or equalsImpl are null</exception>
+        /// <returns></returns>
+        public static IEnumerable<T> Distinct<T>(this IEnumerable<T> seq,
+                                                 Func<T, T, bool> equalsImpl,
+                                                 Func<T, int> hashImpl = null)
+        {
+            if (seq == null)
+                throw new ArgumentNullException("seq");
+            if (equalsImpl == null)
+                throw new ArgumentNullException("equalsImpl");
+
+            var comparer = new DelegateEqualityComparer<T>(equalsImpl, hashImpl);
+            return seq.Distinct(comparer);
+        }
     }
 }

--- a/Tests/DelegateEqualityComparerTests.cs
+++ b/Tests/DelegateEqualityComparerTests.cs
@@ -1,0 +1,53 @@
+﻿using CoreTechs.Common;
+using NUnit.Framework;
+
+namespace Tests
+{
+    public class DelegateEqualityComparerTests
+    {
+        [Test]
+        public void CanMakeEqualityTest()
+        {
+            var first = new ExampleClass {Number = 1, Word = "Hat"};
+            var second = new ExampleClass {Number = 1, Word = "Sock"};
+            var comparer = new DelegateEqualityComparer<ExampleClass>((c1, c2) => c1.Number == c2.Number);
+
+            var defaultEquals = first == second;
+            var result = comparer.Equals(first, second);
+
+            Assume.That(defaultEquals, Is.False);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void CanAlsoRecognizeInequality()
+        {
+            var first = new ExampleClass { Number = 1, Word = "Hat" };
+            var second = new ExampleClass { Number = 2, Word = "Hat" };
+            var comparer = new DelegateEqualityComparer<ExampleClass>((c1, c2) => c1.Number == c2.Number);
+
+            var defaultEquals = first == second;
+            var result = comparer.Equals(first, second);
+
+            Assume.That(defaultEquals, Is.False);
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void CanComputeHashOfClass()
+        {
+            var first = new ExampleClass();
+            var comparer = new DelegateEqualityComparer<ExampleClass>((c1, c2) => false, c => 1);
+
+            var result = comparer.GetHashCode(first);
+
+            Assert.That(result, Is.EqualTo(1));
+        }
+
+        private class ExampleClass
+        {
+            public int Number { get; set; }
+            public string Word { get; set; }
+        }
+    }
+}

--- a/Tests/DelegateEqualityComparerTests.cs
+++ b/Tests/DelegateEqualityComparerTests.cs
@@ -44,6 +44,48 @@ namespace Tests
             Assert.That(result, Is.EqualTo(1));
         }
 
+        [Test]
+        public void NullWithNonNullIsAlwaysUnequal()
+        {
+            var otherClass = new ExampleClass();
+            var trueComparer = new DelegateEqualityComparer<ExampleClass>((c1, c2) => true);
+
+            var result = trueComparer.Equals(null, otherClass);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void NullsAreEqual()
+        {
+            var falseComparer = new DelegateEqualityComparer<ExampleClass>((c1, c2) => false);
+
+            var result = falseComparer.Equals(null, null);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void SelfIsAlwaysEqualWithSelf()
+        {
+            var self = new ExampleClass();
+            var falseComparer = new DelegateEqualityComparer<ExampleClass>((c1, c2) => false);
+
+            var result = falseComparer.Equals(self, self);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void NullsHaveHashOfZero()
+        {
+            var comparer = new DelegateEqualityComparer<ExampleClass>((c1, c2) => false, c => 1);
+
+            var result = comparer.GetHashCode(null);
+
+            Assert.That(result, Is.EqualTo(0));
+        }
+
         private class ExampleClass
         {
             public int Number { get; set; }

--- a/Tests/Enumerable/Tests.cs
+++ b/Tests/Enumerable/Tests.cs
@@ -93,12 +93,56 @@ namespace Tests.Enumerable
 
         }
 
+        private ExampleClass[] _exampleList;
+
+        [SetUp]
+        public void SetUpExampleListForDistinctTests()
+        {
+            _exampleList = new[]
+            {
+                new ExampleClass(1, "Hat"),
+                new ExampleClass(1, "Shoe"),
+            };
+        }
+
+        [Test]
+        public void CanGetDistinctElementsOnNumber()
+        {
+            Func<ExampleClass, ExampleClass, bool> equalityOnNumberImpl = (c1, c2) => c1.Number == c2.Number;
+
+            var distinctOnNumber = _exampleList.Distinct(equalityOnNumberImpl).ToList();
+
+            Assert.That(distinctOnNumber, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void CanGetDistinctElementsOnWord()
+        {
+            Func<ExampleClass, ExampleClass, bool> equalityOnWordImpl = (c1, c2) => string.Equals(c1.Word, c2.Word);
+
+            var distinctOnWord = _exampleList.Distinct(equalityOnWordImpl).ToList();
+
+            Assert.That(distinctOnWord, Has.Count.EqualTo(2));
+        }
+
         IEnumerable<long> CreateSequence()
         {
             while (true)
             {
                 yield return Environment.TickCount;
             }
+        }
+
+        private class ExampleClass
+        {
+            public ExampleClass(int number, string word)
+            {
+                Number = number;
+                Word = word;
+            }
+
+            public int Number { get; set; }
+            public string Word { get; set; }
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="ByteSizeTests.cs" />
     <Compile Include="ClockTests.cs" />
     <Compile Include="DatabaseRelatedTests.cs" />
+    <Compile Include="DelegateEqualityComparerTests.cs" />
     <Compile Include="DisposableTests.cs" />
     <Compile Include="Enumerable\Tests.cs" />
     <Compile Include="FileSystemTests.cs" />


### PR DESCRIPTION
Hey,

I saw that you added a delegate comparer (I was actually just thinking about contributing this today but found myself 9 days late) but I thought I could add a couple of improvements on top of it.

I added tests, changed the behavior to support nulls and reference equality by default (this adds the assumption that things are equal to themselves, which technically shouldn't be violated by any legitimate equals implementation anyway), and then added a new Distinct extension for IEnumerables which takes advantage of the new delegate comparer.

Take care.