### PR TITLE
Add IdentifiedCollection

### DIFF
--- a/CoreTechs.Common/CoreTechs.Common.csproj
+++ b/CoreTechs.Common/CoreTechs.Common.csproj
@@ -49,6 +49,7 @@
     <Compile Include="ByteSize.cs" />
     <Compile Include="Characters.cs" />
     <Compile Include="DelegateEqualityComparer.cs" />
+    <Compile Include="IdentifiedCollection.cs" />
     <Compile Include="PreFetchingEnumerable.cs" />
     <Compile Include="CompositeDisposable.cs" />
     <Compile Include="Database\ConnectionScope.cs" />

--- a/CoreTechs.Common/IdentifiedCollection.cs
+++ b/CoreTechs.Common/IdentifiedCollection.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+
+namespace CoreTechs.Common
+{
+    public enum UpsertResult
+    {
+        Updated,
+        Inserted,
+    }
+
+    /// <summary>
+    /// Interface describing a collection that stores items that can be quickly looked up by a key.
+    /// It is up to the implementation of the collection whether all items must have a key or whether
+    /// some items may be stored without quick lookup capability.
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    /// <typeparam name="TItem"></typeparam>
+    public interface IIdentifiedCollection<TKey, TItem> : ICollection<TItem>
+    {
+        /// <summary>
+        /// Attempt to update/replace an item (looked up by key). If the key of the item is not in the
+        /// collection, it will be inserted. If the collection supports null keys, null keyed items
+        /// will always be inserted.
+        /// </summary>
+        /// <param name="item">The item to upsert.</param>
+        /// <returns>Whether upsert resulted in an update or insertion</returns>
+        UpsertResult Upsert(TItem item);
+        bool Remove(TKey key);
+        bool ContainsKey(TKey key);
+        bool TryGetValue(TKey key, out TItem value);
+        TItem this[TKey key] { get; }
+
+        IReadOnlyDictionary<TKey, TItem> AsReadOnlyDictionary();
+    }
+
+    /// <summary>
+    /// Class which represents a collection of items which can be looked up with a key. The key for
+    /// the items is described by the <see cref="KeyFinder"/> delegate provided to the class.
+    /// Typically, the key will be embedded in the items themselves in some way.
+    /// </summary>
+    /// <remarks>
+    /// The collection's iteration order is based on the insertion order of the elements.
+    /// 
+    /// It is not required that the <see cref="KeyFinder"/> always return a non-null key. In the case
+    /// that the key is nullable and <see cref="KeyFinder"/> results in null, the item being stored
+    /// will not be reachable using the look-up-by-key methods.
+    /// 
+    /// This class is NOT thread-safe.
+    /// </remarks>
+    /// <typeparam name="TKey">The type of keys in the collection.</typeparam>
+    /// <typeparam name="TItem">The type of items in the collection</typeparam>
+    [DebuggerDisplay("Count = {Count}")]
+    [Serializable]
+    public class IdentifiedCollection<TKey, TItem> : IIdentifiedCollection<TKey, TItem>
+    {
+        /// <summary>
+        /// A function that takes an item and returns a key that should be usable to identify the item.
+        /// </summary>
+        /// <remarks>
+        /// For correct functioning, it is required that the state changes of the item not
+        /// affect the key returned by the delegate. Furthermore, the key identifying the item
+        /// is expected to be unique in the collection. Adding a different item that provides the
+        /// same key as an item already in the <see cref="IdentifiedCollection{TKey,TItem}"/>
+        /// (with exception of null keys) is considered an error and will throw an exception.
+        /// In the case that the key finder returns null for an item, the item can still be stored,
+        /// but it will not have a fast (keyed) way to look it up again.
+        /// </remarks>
+        /// <param name="item">The item used to produce the key.</param>
+        /// <returns>
+        /// A key that can be used to identify/look up the item. If the key type is nullable,
+        /// this is allowed to return null.
+        /// </returns>
+        public delegate TKey KeyFinder(TItem item);
+
+        private readonly Dictionary<TKey, TItem> _dictionary;
+        private readonly List<TItem> _items;
+        private readonly KeyFinder _keyFinder;
+
+        /// <summary>
+        /// Initializes a new instance of the class using the provided delegate as the
+        /// key finder for this <see cref="IdentifiedCollection{TKey,TItem}"/> and using
+        /// the default key equality
+        /// keyComparer.
+        /// </summary>
+        /// <param name="keyFinder">A delegate following the contract of <see cref="KeyFinder"/>.</param>
+        public IdentifiedCollection(KeyFinder keyFinder)
+            : this(keyFinder, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the class using the provided delegate as the
+        /// key finder for this <see cref="IdentifiedCollection{TKey,TItem}"/> and using
+        /// the specified key equality
+        /// keyComparer.
+        /// </summary>
+        /// <param name="keyFinder">A delegate following the contract of <see cref="KeyFinder"/>.</param>
+        /// <param name="keyComparer">An IEqualityComparer used to distinguish keys.</param>
+        public IdentifiedCollection(KeyFinder keyFinder, IEqualityComparer<TKey> keyComparer)
+        {
+            if (keyFinder == null) throw new ArgumentNullException("keyFinder");
+            _keyFinder = keyFinder;
+            _items = new List<TItem>();
+            _dictionary = new Dictionary<TKey, TItem>(keyComparer ?? EqualityComparer<TKey>.Default);
+        }
+
+        #region ICollection Implementation
+        public int Count { get { return _items.Count; } }
+        public bool IsReadOnly { get { return false; } }
+
+        public void Add(TItem item)
+        {
+            AddNonNullKeyFor(item);
+            _items.Add(item);
+        }
+
+        public bool Remove(TItem item)
+        {
+            var key = _keyFinder(item);
+            if (key == null) return _items.Remove(item);
+
+            return _dictionary.Remove(key) && _items.Remove(item);
+        }
+
+        public void Clear()
+        {
+            _dictionary.Clear();
+            _items.Clear();
+        }
+
+        public bool Contains(TItem item)
+        {
+            var key = _keyFinder(item);
+            if (key == null) return _items.Contains(item);
+
+            TItem itemFromDictionary;
+            return _dictionary.TryGetValue(key, out itemFromDictionary) && EqualityComparer<TItem>.Default.Equals(item, itemFromDictionary);
+        }
+
+        public void CopyTo(TItem[] array, int arrayIndex)
+        {
+            _items.CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<TItem> GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+        #endregion ICollection Implementation
+
+        #region Dictionary-like Functionality
+
+        /// <summary>
+        /// Attempt to update/replace an item (looked up by key). If the key of the item is not in the
+        /// collection, it will be inserted. If the collection supports null keys, null keyed items
+        /// will always inserted.
+        /// </summary>
+        /// <remarks>
+        /// The effect on the order of the enumeration is unspecified for now. This may either result
+        /// in the replacement of the position of the item or the removal of the existing item and
+        /// appending of the new item.
+        /// If there is a "good reason" to specify this in the future, the implementation may change.
+        /// </remarks>
+        /// <param name="item">The item to upsert.</param>
+        /// <returns>Whether upsert resulted in an update or insertion</returns>
+        public UpsertResult Upsert(TItem item)
+        {
+            var key = _keyFinder(item);
+            if (key == null)
+            {
+                Add(item);
+                return UpsertResult.Inserted;
+            }
+
+            TItem existingItem;
+            if (!_dictionary.TryGetValue(key, out existingItem))
+            {
+                Add(item);
+                return UpsertResult.Inserted;
+            }
+
+            if (ReferenceEquals(item, existingItem))
+                return UpsertResult.Updated;
+
+            var indexOfExistingItem = _items.IndexOf(existingItem);
+            _dictionary[key] = item;
+            _items[@indexOfExistingItem] = item;
+            return UpsertResult.Updated;
+        }
+
+        public bool Remove(TKey key)
+        {
+            TItem value;
+            return _dictionary.TryGetValue(key, out value) && Remove(value);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return _dictionary.ContainsKey(key);
+        }
+
+        public bool TryGetValue(TKey key, out TItem value)
+        {
+            return _dictionary.TryGetValue(key, out value);
+        }
+
+        public TItem this[TKey key]
+        {
+            get { return _dictionary[key]; }
+        }
+
+        public IReadOnlyDictionary<TKey, TItem> AsReadOnlyDictionary()
+        {
+            return _dictionary;
+        }
+        #endregion Dictionary-like Functionality
+
+        private void AddNonNullKeyFor(TItem item)
+        {
+            var key = _keyFinder(item);
+            if (key != null) _dictionary.Add(key, item);
+        }
+    }
+}

--- a/Tests/IdentifiedCollection/UsingIdentifiedCollectionForEntitiesWithIntegerId.cs
+++ b/Tests/IdentifiedCollection/UsingIdentifiedCollectionForEntitiesWithIntegerId.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CoreTechs.Common;
+using NUnit.Framework;
+
+namespace Tests.IdentifiedCollection
+{
+    [TestFixture]
+    public class UsingIdentifiedCollectionForEntitiesWithIntegerId
+    {
+        private IIdentifiedCollection<int, Entity> _identifiedCollection;
+
+        [SetUp]
+        public void GivenLoadedIdentifiedCollection()
+        {
+            _identifiedCollection = new IdentifiedCollection<int, Entity>(e => e.Id)
+            {
+                new Entity(1, "one"),
+                new Entity(2, "two"),
+                new Entity(3, "three"),
+            };
+        }
+
+        [TestCase(1, Result = "one")]
+        [TestCase(2, Result = "two")]
+        [TestCase(3, Result = "three")]
+        public string CanLookUpEntitiesByKey(int key)
+        {
+            return _identifiedCollection[key].Data;
+        }
+
+        [TestCase(0, Result = false)]
+        [TestCase(1, Result = true)]
+        [TestCase(2, Result = true)]
+        [TestCase(3, Result = true)]
+        [TestCase(4, Result = false)]
+        [TestCase(5, Result = false)]
+        public bool CanSeeWhetherKeyIsContained(int key)
+        {
+            return _identifiedCollection.ContainsKey(key);
+        }
+
+        [TestCase(4)]
+        [TestCase(5)]
+        [TestCase(0)]
+        public void MissingKeysThrowExceptions(int key)
+        {
+            Assume.That(!_identifiedCollection.ContainsKey(key));
+            Entity item;
+
+            TestDelegate gettingItemByMissingKey = () => item = _identifiedCollection[key];
+
+            Assert.Throws<KeyNotFoundException>(gettingItemByMissingKey);
+        }
+
+        [Test]
+        public void CanTryToGetItemsWithKey()
+        {
+            Entity missingItem;
+            Entity existingItem;
+
+            var foundMissingItem = _identifiedCollection.TryGetValue(4, out missingItem);
+            var foundExistingItem = _identifiedCollection.TryGetValue(3, out existingItem);
+
+            Assert.That(foundMissingItem, Is.False);
+            Assert.That(foundExistingItem, Is.True);
+            Assert.That(existingItem, Is.Not.Null);
+            Assert.That(existingItem.Data, Is.EqualTo("three"));
+        }
+
+        [Test]
+        public void IteratingOverItemsResultsInSameOrderAsInsertion()
+        {
+            var incrementingIdCol = new IdentifiedCollection<int, Entity>(it => it.Id);
+            foreach (var i in System.Linq.Enumerable.Range(1, 10))
+                incrementingIdCol.Add(new Entity(i, string.Empty));
+
+            var prevId = 0;
+            foreach (var item in incrementingIdCol)
+            {
+                Assert.That(item.Id, Is.EqualTo(prevId + 1));
+                prevId = item.Id;
+            }
+        }
+
+        [Test]
+        public void CanClearItemsFromCollection()
+        {
+            Assume.That(_identifiedCollection, Is.Not.Empty);
+            Assume.That(_identifiedCollection.ContainsKey(1), Is.True);
+
+            _identifiedCollection.Clear();
+
+            Assert.That(_identifiedCollection, Is.Empty);
+            Assert.That(_identifiedCollection.ContainsKey(1), Is.False);
+        }
+
+        [Test]
+        public void CanRemoveBasedOnKey()
+        {
+            Assume.That(_identifiedCollection, Has.Count.GreaterThan(0));
+            var entityToRemove = _identifiedCollection.First();
+
+            var entityWasRemoved = _identifiedCollection.Remove(entityToRemove.Id);
+
+            Assert.That(entityWasRemoved);
+            Assert.That(_identifiedCollection.ContainsKey(entityToRemove.Id), Is.False, "The key should have been removed from the collection");
+            Assert.That(_identifiedCollection.Contains(entityToRemove), Is.False, "The entity should have been removed from the collection");
+        }
+
+        [Test]
+        public void CantInsertItemsThatWouldDuplicateKeys()
+        {
+            Assume.That(_identifiedCollection.ContainsKey(1));
+            var duplicateEntity = new Entity(1, "Impossible To Insert");
+
+            TestDelegate insertionOfDuplicateEntity = () => _identifiedCollection.Add(duplicateEntity);
+
+            Assert.Throws<ArgumentException>(insertionOfDuplicateEntity);
+        }
+
+        [Test]
+        public void CanUpsertNewItems()
+        {
+            Assume.That(!_identifiedCollection.ContainsKey(4));
+            var newEntity = new Entity(4, "four");
+
+            var result = _identifiedCollection.Upsert(newEntity);
+
+            Assert.That(result, Is.EqualTo(UpsertResult.Inserted));
+            Assert.That(_identifiedCollection, Has.Count.EqualTo(4));
+        }
+
+        [Test]
+        public void CanUpsertReplacingItems()
+        {
+            Assume.That(_identifiedCollection.ContainsKey(2));
+            var changedEntity = new Entity(2, "changed");
+            var existingEntity = _identifiedCollection[2];
+
+            var result = _identifiedCollection.Upsert(changedEntity);
+
+            Assert.That(result, Is.EqualTo(UpsertResult.Updated));
+            Assert.That(_identifiedCollection, Has.Count.EqualTo(3));
+            Assert.That(_identifiedCollection[2].Data, Is.EqualTo("changed"));
+            Assert.That(existingEntity.Data, Is.EqualTo("two"));
+        }
+
+        [Test]
+        public void CanUpsertExistingItems()
+        {
+            Assume.That(_identifiedCollection, Is.Not.Empty);
+            var existingEntity = _identifiedCollection.First();
+
+            var result = _identifiedCollection.Upsert(existingEntity);
+
+            Assert.That(result, Is.EqualTo(UpsertResult.Updated));
+            Assert.That(_identifiedCollection, Has.Count.EqualTo(3));
+        }
+
+        #region Classes used for tests
+        private class Entity
+        {
+            public int Id { get; private set; }
+            public string Data { get; private set; }
+
+            public Entity(int id, string data)
+            {
+                Id = id;
+                Data = data;
+            }
+        }
+        #endregion Classes used for tests
+    }
+}

--- a/Tests/IdentifiedCollection/UsingIdentifiedCollectionForEntitiesWithNullableId.cs
+++ b/Tests/IdentifiedCollection/UsingIdentifiedCollectionForEntitiesWithNullableId.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CoreTechs.Common;
+using NUnit.Framework;
+
+namespace Tests.IdentifiedCollection
+{
+    [TestFixture]
+    public class UsingIdentifiedCollectionForEntitiesWithNullableId
+    {
+        private IIdentifiedCollection<int?, Entity> _identifiedCollection;
+
+        [SetUp]
+        public void GivenLoadedIdentifiedCollection()
+        {
+            _identifiedCollection = new IdentifiedCollection<int?, Entity>(e => e.Id == 0 ? (int?)null : e.Id)
+            {
+                new Entity(0, "Zero1"),
+                new Entity(0, "Zero2"),
+                new Entity(0, "Zero3"),
+                new Entity(1, "one"),
+                new Entity(2, "two"),
+            };
+        }
+
+        [TestCase(1, Result = "one")]
+        [TestCase(2, Result = "two")]
+        public string CanLookUpEntitiesByKey(int key)
+        {
+            return _identifiedCollection[key].Data;
+        }
+
+        [TestCase(3)]
+        [TestCase(4)]
+        [TestCase(0)]
+        public void MissingKeysThrowExceptions(int key)
+        {
+            Assume.That(!_identifiedCollection.ContainsKey(key));
+            Entity item;
+
+            TestDelegate gettingItemByMissingKey = () => item = _identifiedCollection[key];
+
+            Assert.Throws<KeyNotFoundException>(gettingItemByMissingKey);
+        }
+
+        [Test]
+        public void WhenIteratingKeylessItemsExist()
+        {
+            var expectedData = new[] { "Zero1", "Zero2", "Zero3", "one", "two" };
+
+            Assert.That(_identifiedCollection.LongCount(), Is.EqualTo(5));
+            Assert.That(_identifiedCollection.Select(it => it.Data), Is.EquivalentTo(expectedData));
+        }
+
+        [Test]
+        public void WhenViewingAsReadOnlyDictionaryKeylessItemsDontExist()
+        {
+            var asDict = _identifiedCollection.AsReadOnlyDictionary();
+            var expectedData = new[] { "one", "two" };
+
+            Assert.That(asDict.LongCount(), Is.EqualTo(2));
+            Assert.That(asDict.Keys.LongCount(), Is.EqualTo(2));
+            Assert.That(asDict.Values.Select(en => en.Data), Is.EquivalentTo(expectedData));
+        }
+
+        [Test]
+        public void UpsertingNullsAlwaysInserts()
+        {
+            Assume.That(_identifiedCollection, Has.Count.EqualTo(5));
+
+            var zeroEntity = new Entity(0, "newzero");
+
+            var results = new[]
+            {
+                _identifiedCollection.Upsert(zeroEntity),
+                _identifiedCollection.Upsert(zeroEntity),
+                _identifiedCollection.Upsert(zeroEntity),
+            };
+
+            Assert.That(results, Is.All.EqualTo(UpsertResult.Inserted));
+            Assert.That(_identifiedCollection, Has.Count.EqualTo(8));
+            Assert.That(_identifiedCollection.Last().Data, Is.EqualTo("newzero"));
+        }
+
+        #region Classes used for tests
+        private class Entity
+        {
+            public int Id { get; private set; }
+            public string Data { get; private set; }
+
+            public Entity(int id, string data)
+            {
+                Id = id;
+                Data = data;
+            }
+        }
+        #endregion
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -54,6 +54,8 @@
     <Compile Include="DisposableTests.cs" />
     <Compile Include="Enumerable\Tests.cs" />
     <Compile Include="FileSystemTests.cs" />
+    <Compile Include="IdentifiedCollection\UsingIdentifiedCollectionForEntitiesWithIntegerId.cs" />
+    <Compile Include="IdentifiedCollection\UsingIdentifiedCollectionForEntitiesWithNullableId.cs" />
     <Compile Include="LRUCacheTests.cs" />
     <Compile Include="MsgLoopTests.cs" />
     <Compile Include="DateTimeSpanTests.cs" />


### PR DESCRIPTION
An `IdentifiedCollection` is a collection of items that can be identified using a key. The `IdentifiedCollection`'s constructor takes a delegate that is used to derive the key used to look up an item. Items' keys are generated by that `KeyFinder` when the item is inserted and the item may be either looked up by this key or iterated over like a normal collection.

The goals for this data structure is:

1. Provide an easy/relatively fast way to look up items in the collection based on a key for an item.
2. Maintain that keys must be derivable by the items.
3. Maintain the order of the items' iteration as inserted (which is a major distinction from a regular dictionary with manually managed keys).

Comments? One thing I had a lot of difficulty with was the naming of this thing. Still not satisfied, but I couldn't come up with anything any better.