### PR TITLE
Added modelstate attributes and EF update

### DIFF
--- a/CoreTechs.Common/App.config
+++ b/CoreTechs.Common/App.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/CoreTechs.Common/CoreTechs.Common.csproj
+++ b/CoreTechs.Common/CoreTechs.Common.csproj
@@ -33,7 +33,16 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Security" />
@@ -41,6 +50,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -51,6 +61,9 @@
     <Compile Include="Database\SqlDataTransfer.cs" />
     <Compile Include="DelegateEqualityComparer.cs" />
     <Compile Include="IdentifiedCollection.cs" />
+    <Compile Include="Mvc\ExportModelStateToTempData.cs" />
+    <Compile Include="Mvc\ImportModelStateFromTempData.cs" />
+    <Compile Include="Mvc\ModelStateTempDataTransfer.cs" />
     <Compile Include="PreFetchingEnumerable.cs" />
     <Compile Include="CompositeDisposable.cs" />
     <Compile Include="Database\ConnectionScope.cs" />
@@ -100,6 +113,10 @@
     <Compile Include="Text\ICsvWritable.cs" />
     <Compile Include="Text\Record.cs" />
     <Compile Include="ConversionExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CoreTechs.Common/Database/Extensions.cs
+++ b/CoreTechs.Common/Database/Extensions.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using CoreTechs.Common.Reflection;
+using System.Data.Entity;
 
 namespace CoreTechs.Common.Database
 {
@@ -586,6 +588,50 @@ namespace CoreTechs.Common.Database
         {
             if (dataSet == null) throw new ArgumentNullException("dataSet");
             return dataSet.AsEnumerable().Select(row => row.Create<T>());
+        }
+
+
+
+        /*
+         * Credit to Graham O'Neale
+         * http://stackoverflow.com/questions/3642371/how-to-update-only-one-field-using-entity-framework
+         */
+        /// <summary>
+        /// Sets each provided property to Modified. Changes are not saved to the database.
+        /// </summary>       
+        /// <param name="context">The database context</param>
+        /// <param name="entity">The entity being updated. This entity cannot already be attached to the Entity graph.</param>
+        /// <param name="properties"> A list of property names to be set to modified. </param>
+        /// <returns>True if no error was thrown.</returns>
+        public static bool Update<T>(this DbContext context, T entity, params string[] properties) where T : class, new()
+        {
+            context.Set<T>().Attach(entity);
+            foreach (var property in properties)
+            {
+                context.Entry(entity).Property(property).IsModified = true;
+            }
+            return true;
+        }
+
+        /*
+         * Credit to Ladislav Mrnka
+         * http://stackoverflow.com/questions/5749110/readonly-properties-in-ef-4-1/5749469#5749469
+         */
+        /// <summary>
+        /// Sets each provided property to Modified. Changes are not saved to the database.
+        /// </summary>
+        /// <param name="context">The database context</param>
+        /// <param name="entity">The entity being updated. This entity cannot already be attached to the Entity graph.</param>
+        /// <param name="properties"> A list of expressions providing the properties to set as modified.</param>
+        /// <returns>True if no error was thrown.</returns>
+        public static bool Update<T>(this DbContext context, T entity, params Expression<Func<T, object>>[] properties) where T : class, new()
+        {
+            context.Set<T>().Attach(entity);
+            foreach (var selector in properties)
+            {
+                context.Entry(entity).Property(selector).IsModified = true;
+            }
+            return true;
         }
 
     }

--- a/CoreTechs.Common/Mvc/ExportModelStateToTempData.cs
+++ b/CoreTechs.Common/Mvc/ExportModelStateToTempData.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+
+namespace CoreTechs.Common.Mvc
+{
+    /*
+     * Credit to Kazi Manzur Rashid for his ModelState transfer filters
+     * http://weblogs.asp.net/rashid/asp-net-mvc-best-practices-part-1
+     */
+    public class ExportModelStateToTempData : ModelStateTempDataTransfer
+    {
+        public override void OnActionExecuted(ActionExecutedContext filterContext)
+        {
+            //Only export when ModelState is not valid
+            if (!filterContext.Controller.ViewData.ModelState.IsValid)
+            {
+                //Export if we are redirecting
+                if ((filterContext.Result is RedirectResult) || (filterContext.Result is RedirectToRouteResult))
+                {
+                    filterContext.Controller.TempData[Key] = filterContext.Controller.ViewData.ModelState;
+                }
+            }
+
+            base.OnActionExecuted(filterContext);
+        }
+    }
+}

--- a/CoreTechs.Common/Mvc/ImportModelStateFromTempData.cs
+++ b/CoreTechs.Common/Mvc/ImportModelStateFromTempData.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+
+namespace CoreTechs.Common.Mvc
+{
+    /*
+     * Credit to Kazi Manzur Rashid for his ModelState transfer filters
+     * http://weblogs.asp.net/rashid/asp-net-mvc-best-practices-part-1
+     */
+    public class ImportModelStateFromTempData : ModelStateTempDataTransfer
+    {
+        public override void OnActionExecuted(ActionExecutedContext filterContext)
+        {
+            ModelStateDictionary modelState = filterContext.Controller.TempData[Key] as ModelStateDictionary;
+
+            if (modelState != null)
+            {
+                //Only Import if we are viewing
+                if (filterContext.Result is ViewResult)
+                {
+                    filterContext.Controller.ViewData.ModelState.Merge(modelState);
+                }
+                else
+                {
+                    //Otherwise remove it.
+                    filterContext.Controller.TempData.Remove(Key);
+                }
+            }
+            base.OnActionExecuted(filterContext);
+        }
+    }
+}

--- a/CoreTechs.Common/Mvc/ModelStateTempDataTransfer.cs
+++ b/CoreTechs.Common/Mvc/ModelStateTempDataTransfer.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+
+namespace CoreTechs.Common.Mvc
+{
+    /*
+     * Credit to Kazi Manzur Rashid for his ModelState transfer filters
+     * http://weblogs.asp.net/rashid/asp-net-mvc-best-practices-part-1
+     */
+    public abstract class ModelStateTempDataTransfer : ActionFilterAttribute
+    {
+        protected static readonly string Key = typeof(ModelStateTempDataTransfer).FullName;
+    }
+}

--- a/CoreTechs.Common/packages.config
+++ b/CoreTechs.Common/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+</packages>

--- a/Tests/App.config
+++ b/Tests/App.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -30,6 +30,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core">
       <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.0.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
     </Reference>
@@ -37,6 +45,7 @@
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml.Linq" />
@@ -76,6 +85,7 @@
     <Compile Include="TypeConversionTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
     <None Include="Text\WithHeader.csv" />
     <None Include="Text\EmptyFields.csv" />

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
ImportModelStateFromTempData and ExportModelStateToTempData allow automatic passing of Model validation errors from post actions to redirected view actions using only the two attributes. This is allows for convenient MVC error handling using the PRG pattern. 

The DbContext extensions Update<T> provides convenient property specific updates to posted entities using EF. 

All methods and classes originated from SO, and credit has been cited, but I find myself adding these to every project I work on, so it would be nice to have them included in the Common library.